### PR TITLE
Implement typed world grid and pixel renderer

### DIFF
--- a/src/elements.js
+++ b/src/elements.js
@@ -1,3 +1,18 @@
+export const ELEMENTS = Object.freeze({
+  EMPTY: 0,
+  WALL: 1,
+  SAND: 2,
+});
+
+export const PALETTE = new Uint8ClampedArray([
+  // EMPTY
+  7, 9, 15, 255,
+  // WALL
+  54, 57, 66, 255,
+  // SAND
+  237, 201, 81, 255,
+]);
+
 export function createGameElements() {
   const canvas = document.getElementById('game-canvas');
 

--- a/src/main.js
+++ b/src/main.js
@@ -1,4 +1,4 @@
-import { createGameElements } from './elements.js';
+import { createGameElements, ELEMENTS } from './elements.js';
 import { createRenderer } from './render.js';
 import { createSimulation } from './sim.js';
 import { initializeUI } from './ui.js';
@@ -8,6 +8,47 @@ const simulation = createSimulation();
 const renderer = createRenderer(elements.canvas, elements.context);
 const ui = initializeUI(elements.canvas);
 const viewport = window.visualViewport;
+
+const world = simulation.state.world;
+
+function paintDebugWorld(targetWorld) {
+  if (!targetWorld) {
+    return;
+  }
+
+  const { width, height, cells } = targetWorld;
+  const { idx } = targetWorld;
+
+  if (width === 0 || height === 0) {
+    return;
+  }
+
+  // Draw a WALL border around the world bounds.
+  for (let x = 0; x < width; x += 1) {
+    cells[idx(x, 0)] = ELEMENTS.WALL;
+    cells[idx(x, Math.max(height - 1, 0))] = ELEMENTS.WALL;
+  }
+
+  for (let y = 0; y < height; y += 1) {
+    cells[idx(0, y)] = ELEMENTS.WALL;
+    cells[idx(Math.max(width - 1, 0), y)] = ELEMENTS.WALL;
+  }
+
+  // Fill a 100x100 area with SAND (or as large as fits inside the border).
+  const sandWidth = Math.max(Math.min(100, width - 2), 0);
+  const sandHeight = Math.max(Math.min(100, height - 2), 0);
+
+  for (let y = 0; y < sandHeight; y += 1) {
+    const row = y + 1;
+    for (let x = 0; x < sandWidth; x += 1) {
+      cells[idx(x + 1, row)] = ELEMENTS.SAND;
+    }
+  }
+}
+
+paintDebugWorld(world);
+
+renderer.resize(world);
 
 let frameHandle = null;
 let lastTimestamp = 0;
@@ -31,7 +72,7 @@ function start() {
     return;
   }
 
-  renderer.resize();
+  renderer.resize(simulation.state.world);
   lastTimestamp = 0;
   frameHandle = window.requestAnimationFrame(loop);
 }
@@ -46,11 +87,11 @@ function stop() {
 }
 
 function handleResize() {
-  renderer.resize();
+  renderer.resize(simulation.state.world);
 }
 
 function handleViewportChange() {
-  renderer.resize();
+  renderer.resize(simulation.state.world);
 }
 
 function handleVisibilityChange() {

--- a/src/sim.js
+++ b/src/sim.js
@@ -1,10 +1,94 @@
-export function createSimulation() {
+const DEFAULT_WORLD_WIDTH = 256;
+const DEFAULT_WORLD_HEIGHT = 256;
+
+function normalizeDimension(value, fallback) {
+  const numeric = Number(value);
+
+  if (!Number.isFinite(numeric) || numeric <= 0) {
+    return fallback;
+  }
+
+  const integer = Math.floor(numeric);
+
+  if (integer <= 0) {
+    return fallback;
+  }
+
+  return integer;
+}
+
+function normalizeCoordinate(value) {
+  const numeric = Number(value);
+
+  if (!Number.isFinite(numeric)) {
+    return NaN;
+  }
+
+  return Math.trunc(numeric);
+}
+
+export function createWorld(width, height) {
+  const normalizedWidth = normalizeDimension(width, DEFAULT_WORLD_WIDTH);
+  const normalizedHeight = normalizeDimension(height, DEFAULT_WORLD_HEIGHT);
+  const cellCount = normalizedWidth * normalizedHeight;
+
+  const cells = new Uint16Array(cellCount);
+  const flags = new Uint8Array(cellCount);
+
+  function inBounds(x, y) {
+    const ix = normalizeCoordinate(x);
+    const iy = normalizeCoordinate(y);
+
+    return (
+      Number.isFinite(ix) &&
+      Number.isFinite(iy) &&
+      ix >= 0 &&
+      ix < normalizedWidth &&
+      iy >= 0 &&
+      iy < normalizedHeight
+    );
+  }
+
+  function idx(x, y) {
+    const ix = normalizeCoordinate(x);
+    const iy = normalizeCoordinate(y);
+
+    if (!Number.isFinite(ix) || !Number.isFinite(iy)) {
+      throw new RangeError('Cell coordinates must be finite numbers.');
+    }
+
+    if (ix < 0 || ix >= normalizedWidth || iy < 0 || iy >= normalizedHeight) {
+      throw new RangeError(`Cell coordinates out of bounds: (${x}, ${y})`);
+    }
+
+    return iy * normalizedWidth + ix;
+  }
+
+  return {
+    width: normalizedWidth,
+    height: normalizedHeight,
+    cells,
+    flags,
+    idx,
+    inBounds,
+  };
+}
+
+export function createSimulation(options = {}) {
+  const width = normalizeDimension(options.width, DEFAULT_WORLD_WIDTH);
+  const height = normalizeDimension(options.height, DEFAULT_WORLD_HEIGHT);
+  const world = createWorld(width, height);
+
   const state = {
-    message: 'Hello world',
+    world,
     elapsed: 0,
   };
 
   function update(deltaSeconds) {
+    if (!Number.isFinite(deltaSeconds)) {
+      return;
+    }
+
     state.elapsed += deltaSeconds;
   }
 


### PR DESCRIPTION
## Summary
- add element constants and palette definitions for rendering
- create a typed world grid with indexing helpers inside the simulation state
- render the world via ImageData and temporarily paint sand and wall samples to the grid

## Testing
- No automated tests were run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68ca0c48f6b8832bb2b4c80bbff27f47