### PR TITLE
Implement Phase 2 features with self-checks

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,5 +18,6 @@
     </main>
     <noscript>You need to enable JavaScript to run this game.</noscript>
     <script type="module" src="./src/main.js"></script>
+    <script type="module" src="./src/selfcheck.js"></script>
   </body>
 </html>

--- a/src/elements.js
+++ b/src/elements.js
@@ -13,6 +13,10 @@ export const PALETTE = new Uint8ClampedArray([
   237, 201, 81, 255,
 ]);
 
+export const EMPTY = ELEMENTS.EMPTY;
+export const WALL = ELEMENTS.WALL;
+export const SAND = ELEMENTS.SAND;
+
 export function createGameElements() {
   const canvas = document.getElementById('game-canvas');
 

--- a/src/main.js
+++ b/src/main.js
@@ -1,54 +1,505 @@
-import { createGameElements, ELEMENTS } from './elements.js';
+import {
+  createGameElements,
+  ELEMENTS,
+  PALETTE as RAW_PALETTE,
+  EMPTY,
+  WALL,
+  SAND,
+} from './elements.js';
 import { createRenderer } from './render.js';
-import { createSimulation } from './sim.js';
+import { createSimulation, paintCircle } from './sim.js';
 import { initializeUI } from './ui.js';
+import { runSelfChecks } from './selfcheck.js';
+
+const MAX_WRITES_PER_FRAME = 50000;
+const DEFAULT_BRUSH_SIZE = 6;
+const FPS_SMOOTHING = 0.12;
+const THROTTLE_NOTICE_MS = 800;
+
+function createPaletteLookup(rawPalette) {
+  if (!rawPalette) {
+    return {};
+  }
+
+  const lookup = {};
+  const entryCount = Math.floor(rawPalette.length / 4);
+
+  for (let id = 0; id < entryCount; id += 1) {
+    const offset = id * 4;
+    lookup[id] = [
+      rawPalette[offset],
+      rawPalette[offset + 1],
+      rawPalette[offset + 2],
+      rawPalette[offset + 3],
+    ];
+  }
+
+  return lookup;
+}
+
+function createElementNameMap() {
+  const names = {};
+
+  for (const [name, id] of Object.entries(ELEMENTS)) {
+    const label = name.charAt(0) + name.slice(1).toLowerCase();
+    names[id] = label;
+  }
+
+  return names;
+}
+
+function isFormField(element) {
+  if (!(element instanceof HTMLElement)) {
+    return false;
+  }
+
+  const tagName = element.tagName.toLowerCase();
+  return (
+    tagName === 'input' ||
+    tagName === 'textarea' ||
+    element.isContentEditable ||
+    tagName === 'select'
+  );
+}
+
+function createDebugOverlay(visible) {
+  const overlay = document.createElement('div');
+  overlay.id = 'powder-debug-overlay';
+  overlay.style.position = 'fixed';
+  overlay.style.top = '8px';
+  overlay.style.left = '8px';
+  overlay.style.padding = '0.5rem 0.65rem';
+  overlay.style.background = 'rgba(9, 12, 22, 0.78)';
+  overlay.style.color = '#c7d5ff';
+  overlay.style.fontFamily = 'monospace';
+  overlay.style.fontSize = '12px';
+  overlay.style.lineHeight = '1.45';
+  overlay.style.borderRadius = '10px';
+  overlay.style.boxShadow = '0 6px 14px rgba(0, 0, 0, 0.45)';
+  overlay.style.pointerEvents = 'none';
+  overlay.style.zIndex = '1500';
+
+  const fpsLine = document.createElement('div');
+  const rafLine = document.createElement('div');
+  const canvasLine = document.createElement('div');
+  const noticeLine = document.createElement('div');
+  noticeLine.style.color = '#ffba66';
+  noticeLine.style.fontWeight = '600';
+
+  overlay.append(fpsLine, rafLine, canvasLine, noticeLine);
+
+  if (!visible) {
+    overlay.style.display = 'none';
+  }
+
+  document.body.appendChild(overlay);
+
+  return {
+    element: overlay,
+    update({ fps, frameCount, canvasWidth, canvasHeight, throttled }) {
+      fpsLine.textContent = `FPS: ${fps.toFixed(1)}`;
+      rafLine.textContent = `RAF: ${frameCount}`;
+      canvasLine.textContent = `Canvas: ${canvasWidth}×${canvasHeight}`;
+      noticeLine.textContent = throttled ? 'Painting throttled' : '';
+    },
+    destroy() {
+      overlay.remove();
+    },
+  };
+}
+
+const layout = { toolbarHeight: 0 };
+const paletteLookup = Object.freeze(createPaletteLookup(RAW_PALETTE));
+const elementNames = createElementNameMap();
 
 const elements = createGameElements();
+
+if (elements.canvas && elements.canvas.id !== 'game') {
+  elements.canvas.id = 'game';
+}
+
+elements.names = elementNames;
+
 const simulation = createSimulation();
-const renderer = createRenderer(elements.canvas, elements.context);
-const ui = initializeUI(elements.canvas);
-const viewport = window.visualViewport;
+const renderer = createRenderer(elements.canvas, elements.context, {
+  palette: RAW_PALETTE,
+  getToolbarHeight: () => layout.toolbarHeight,
+});
 
 const world = simulation.state.world;
+const stateListeners = new Set();
 
-function paintDebugWorld(targetWorld) {
-  if (!targetWorld) {
-    return;
-  }
+const Game = {
+  elements,
+  simulation,
+  renderer,
+  layout,
+  state: {
+    paused: false,
+    brushSize: DEFAULT_BRUSH_SIZE,
+    currentElementId: ELEMENTS.SAND,
+    erasing: false,
+  },
+  metrics: {
+    frameCount: 0,
+    fps: 0,
+  },
+};
 
-  const { width, height, cells } = targetWorld;
-  const { idx } = targetWorld;
+Game.ELEMENTS = ELEMENTS;
+Game.PALETTE = paletteLookup;
+Game.constants = { EMPTY, WALL, SAND };
+Game.getElementName = function getElementName(elementId) {
+  return elementNames[elementId] ?? `Element ${elementId}`;
+};
 
-  if (width === 0 || height === 0) {
-    return;
-  }
+window.PALETTE = paletteLookup;
+window.EMPTY = EMPTY;
+window.WALL = WALL;
+window.SAND = SAND;
 
-  // Draw a WALL border around the world bounds.
-  for (let x = 0; x < width; x += 1) {
-    cells[idx(x, 0)] = ELEMENTS.WALL;
-    cells[idx(x, Math.max(height - 1, 0))] = ELEMENTS.WALL;
-  }
-
-  for (let y = 0; y < height; y += 1) {
-    cells[idx(0, y)] = ELEMENTS.WALL;
-    cells[idx(Math.max(width - 1, 0), y)] = ELEMENTS.WALL;
-  }
-
-  // Fill a 100x100 area with SAND (or as large as fits inside the border).
-  const sandWidth = Math.max(Math.min(100, width - 2), 0);
-  const sandHeight = Math.max(Math.min(100, height - 2), 0);
-
-  for (let y = 0; y < sandHeight; y += 1) {
-    const row = y + 1;
-    for (let x = 0; x < sandWidth; x += 1) {
-      cells[idx(x + 1, row)] = ELEMENTS.SAND;
+function notifyStateChange() {
+  for (const listener of stateListeners) {
+    try {
+      listener(Game.state);
+    } catch (error) {
+      console.error('State listener error', error);
     }
   }
 }
 
-paintDebugWorld(world);
+Game.onStateChange = function onStateChange(listener) {
+  if (typeof listener !== 'function') {
+    return () => {};
+  }
 
-renderer.resize(world);
+  stateListeners.add(listener);
+  return () => {
+    stateListeners.delete(listener);
+  };
+};
+
+Game.setBrushSize = function setBrushSize(size) {
+  const numeric = Number(size);
+  if (!Number.isFinite(numeric)) {
+    return;
+  }
+
+  const clamped = Math.max(1, Math.min(20, Math.round(numeric)));
+
+  if (clamped !== Game.state.brushSize) {
+    Game.state.brushSize = clamped;
+    notifyStateChange();
+  }
+};
+
+Game.setCurrentElementId = function setCurrentElementId(elementId) {
+  const numeric = Number(elementId);
+
+  if (!Number.isFinite(numeric)) {
+    return;
+  }
+
+  const id = Math.max(0, Math.trunc(numeric));
+
+  if (id !== Game.state.currentElementId) {
+    Game.state.currentElementId = id;
+    notifyStateChange();
+  }
+};
+
+Game.togglePause = function togglePause(forceValue) {
+  const next =
+    typeof forceValue === 'boolean' ? forceValue : !Boolean(Game.state.paused);
+
+  if (next !== Game.state.paused) {
+    Game.state.paused = next;
+    notifyStateChange();
+  }
+};
+
+Game.toggleEraser = function toggleEraser(forceValue) {
+  const next =
+    typeof forceValue === 'boolean' ? forceValue : !Boolean(Game.state.erasing);
+
+  if (next !== Game.state.erasing) {
+    Game.state.erasing = next;
+    notifyStateChange();
+  }
+};
+
+Game.clearWorld = function clearWorld() {
+  world.cells.fill(EMPTY);
+  world.flags.fill(0);
+  renderer.draw(world);
+};
+
+let paintFrameIndex = -1;
+let paintWritesThisFrame = 0;
+let throttleNoticeUntil = 0;
+
+Game.paintAtWorld = function paintAtWorld(x, y, radius, elementId) {
+  if (!world || !world.cells) {
+    return 0;
+  }
+
+  const numericX = Number(x);
+  const numericY = Number(y);
+
+  if (!Number.isFinite(numericX) || !Number.isFinite(numericY)) {
+    return 0;
+  }
+
+  const frameCount = Game.metrics.frameCount;
+
+  if (paintFrameIndex !== frameCount) {
+    paintFrameIndex = frameCount;
+    paintWritesThisFrame = 0;
+  }
+
+  if (paintWritesThisFrame >= MAX_WRITES_PER_FRAME) {
+    throttleNoticeUntil = performance.now() + THROTTLE_NOTICE_MS;
+    return 0;
+  }
+
+  const tx = Math.trunc(numericX);
+  const ty = Math.trunc(numericY);
+
+  if (tx < 0 || tx >= world.width || ty < 0 || ty >= world.height) {
+    return 0;
+  }
+
+  const radiusValue = Number.isFinite(radius)
+    ? Math.max(0, Math.trunc(radius))
+    : Game.state.brushSize;
+
+  const brushElement = Number.isFinite(elementId)
+    ? Math.trunc(elementId)
+    : Game.state.erasing
+    ? EMPTY
+    : Game.state.currentElementId;
+
+  const writes = paintCircle(world, tx, ty, radiusValue, brushElement);
+
+  if (writes > 0) {
+    paintWritesThisFrame += writes;
+    if (paintWritesThisFrame >= MAX_WRITES_PER_FRAME) {
+      throttleNoticeUntil = performance.now() + THROTTLE_NOTICE_MS;
+    }
+    renderer.draw(world);
+  }
+
+  return writes;
+};
+
+const pointerState = {
+  touchActive: false,
+  mouseActive: false,
+  pendingPoint: null,
+  scheduled: false,
+};
+
+function clientToWorld(clientX, clientY) {
+  const rect = elements.canvas.getBoundingClientRect();
+
+  if (!rect || rect.width === 0 || rect.height === 0) {
+    return null;
+  }
+
+  const scaleX = world.width / rect.width;
+  const scaleY = world.height / rect.height;
+
+  const worldX = (clientX - rect.left) * scaleX;
+  const worldY = (clientY - rect.top) * scaleY;
+
+  if (!Number.isFinite(worldX) || !Number.isFinite(worldY)) {
+    return null;
+  }
+
+  return { x: worldX, y: worldY };
+}
+
+function processScheduledPaint() {
+  pointerState.scheduled = false;
+
+  if (!pointerState.pendingPoint) {
+    return;
+  }
+
+  const point = pointerState.pendingPoint;
+  pointerState.pendingPoint = null;
+
+  if (point.type === 'touch' && !pointerState.touchActive) {
+    return;
+  }
+
+  if (point.type === 'mouse' && !pointerState.mouseActive) {
+    return;
+  }
+
+  if (Game.ui && typeof Game.ui.isElementModalOpen === 'function') {
+    if (Game.ui.isElementModalOpen()) {
+      return;
+    }
+  }
+
+  const coords = clientToWorld(point.x, point.y);
+
+  if (!coords) {
+    return;
+  }
+
+  Game.paintAtWorld(coords.x, coords.y);
+}
+
+function schedulePaint(point) {
+  pointerState.pendingPoint = point;
+
+  if (!pointerState.scheduled) {
+    pointerState.scheduled = true;
+    window.requestAnimationFrame(processScheduledPaint);
+  }
+}
+
+function handleTouchStart(event) {
+  if (event.touches.length > 1) {
+    if (event.cancelable) {
+      event.preventDefault();
+    }
+    return;
+  }
+
+  const touch = event.touches[0] || event.changedTouches[0];
+
+  if (!touch) {
+    return;
+  }
+
+  pointerState.touchActive = true;
+
+  if (event.cancelable) {
+    event.preventDefault();
+  }
+
+  schedulePaint({ x: touch.clientX, y: touch.clientY, type: 'touch' });
+}
+
+function handleTouchMove(event) {
+  if (!pointerState.touchActive) {
+    return;
+  }
+
+  if (event.touches.length > 1) {
+    if (event.cancelable) {
+      event.preventDefault();
+    }
+    pointerState.touchActive = false;
+    pointerState.pendingPoint = null;
+    return;
+  }
+
+  const touch = event.touches[0] || event.changedTouches[0];
+
+  if (!touch) {
+    return;
+  }
+
+  if (event.cancelable) {
+    event.preventDefault();
+  }
+
+  schedulePaint({ x: touch.clientX, y: touch.clientY, type: 'touch' });
+}
+
+function handleTouchEnd(event) {
+  if (event.cancelable) {
+    event.preventDefault();
+  }
+
+  pointerState.touchActive = event.touches.length > 0;
+  pointerState.pendingPoint = null;
+}
+
+function handleTouchCancel() {
+  pointerState.touchActive = false;
+  pointerState.pendingPoint = null;
+}
+
+function handleMouseDown(event) {
+  if (event.button !== 0) {
+    return;
+  }
+
+  pointerState.mouseActive = true;
+  event.preventDefault();
+  schedulePaint({ x: event.clientX, y: event.clientY, type: 'mouse' });
+}
+
+function handleMouseMove(event) {
+  if (!pointerState.mouseActive) {
+    return;
+  }
+
+  event.preventDefault();
+  schedulePaint({ x: event.clientX, y: event.clientY, type: 'mouse' });
+}
+
+function handleMouseUp(event) {
+  if (event.button !== 0) {
+    return;
+  }
+
+  pointerState.mouseActive = false;
+  pointerState.pendingPoint = null;
+}
+
+function handleMouseLeave() {
+  pointerState.mouseActive = false;
+  pointerState.pendingPoint = null;
+}
+
+const canvas = elements.canvas;
+canvas.addEventListener('touchstart', handleTouchStart, { passive: false });
+canvas.addEventListener('touchmove', handleTouchMove, { passive: false });
+canvas.addEventListener('touchend', handleTouchEnd, { passive: false });
+canvas.addEventListener('touchcancel', handleTouchCancel, { passive: false });
+canvas.addEventListener('mousedown', handleMouseDown);
+canvas.addEventListener('mousemove', handleMouseMove);
+canvas.addEventListener('mouseup', handleMouseUp);
+canvas.addEventListener('mouseleave', handleMouseLeave);
+canvas.addEventListener('contextmenu', (event) => {
+  event.preventDefault();
+});
+
+const debugVisible = new URLSearchParams(window.location.search).get('debug') !== '0';
+const debugOverlay = createDebugOverlay(debugVisible);
+
+function updateDebugOverlay() {
+  if (!debugOverlay) {
+    return;
+  }
+
+  const size = renderer.getCanvasSize();
+  const now = performance.now();
+
+  debugOverlay.update({
+    fps: Game.metrics.fps || 0,
+    frameCount: Game.metrics.frameCount,
+    canvasWidth: size.width,
+    canvasHeight: size.height,
+    throttled: now < throttleNoticeUntil,
+  });
+}
+
+function handleResize() {
+  renderer.resize(world);
+  updateDebugOverlay();
+}
+
+function handleViewportChange() {
+  renderer.resize(world);
+  updateDebugOverlay();
+}
 
 let frameHandle = null;
 let lastTimestamp = 0;
@@ -61,8 +512,24 @@ function loop(timestamp) {
   const deltaSeconds = (timestamp - lastTimestamp) / 1000;
   lastTimestamp = timestamp;
 
-  simulation.update(deltaSeconds);
-  renderer.render(simulation.state);
+  Game.metrics.frameCount += 1;
+
+  if (deltaSeconds > 0) {
+    const instant = 1 / deltaSeconds;
+    if (Game.metrics.fps === 0) {
+      Game.metrics.fps = instant;
+    } else {
+      Game.metrics.fps =
+        Game.metrics.fps * (1 - FPS_SMOOTHING) + instant * FPS_SMOOTHING;
+    }
+  }
+
+  if (!Game.state.paused) {
+    simulation.update(deltaSeconds);
+  }
+
+  renderer.draw(world);
+  updateDebugOverlay();
 
   frameHandle = window.requestAnimationFrame(loop);
 }
@@ -72,7 +539,9 @@ function start() {
     return;
   }
 
-  renderer.resize(simulation.state.world);
+  renderer.resize(world);
+  renderer.draw(world);
+  updateDebugOverlay();
   lastTimestamp = 0;
   frameHandle = window.requestAnimationFrame(loop);
 }
@@ -86,54 +555,191 @@ function stop() {
   frameHandle = null;
 }
 
-function handleResize() {
-  renderer.resize(simulation.state.world);
-}
-
-function handleViewportChange() {
-  renderer.resize(simulation.state.world);
-}
-
 function handleVisibilityChange() {
   if (document.hidden) {
     stop();
-  } else {
+  } else if (frameHandle === null) {
     start();
   }
 }
 
+Game.start = start;
+Game.stop = stop;
+Game.destroy = function destroy() {
+  stop();
+  canvas.removeEventListener('touchstart', handleTouchStart);
+  canvas.removeEventListener('touchmove', handleTouchMove);
+  canvas.removeEventListener('touchend', handleTouchEnd);
+  canvas.removeEventListener('touchcancel', handleTouchCancel);
+  canvas.removeEventListener('mousedown', handleMouseDown);
+  canvas.removeEventListener('mousemove', handleMouseMove);
+  canvas.removeEventListener('mouseup', handleMouseUp);
+  canvas.removeEventListener('mouseleave', handleMouseLeave);
+  document.removeEventListener('visibilitychange', handleVisibilityChange);
+  window.removeEventListener('resize', handleResize);
+  window.removeEventListener('orientationchange', handleResize);
+  if (window.visualViewport) {
+    window.visualViewport.removeEventListener('resize', handleViewportChange);
+    window.visualViewport.removeEventListener('scroll', handleViewportChange);
+  }
+  window.removeEventListener('keydown', handleKeydown);
+  if (Game.ui && typeof Game.ui.destroy === 'function') {
+    Game.ui.destroy();
+  }
+  if (debugOverlay) {
+    debugOverlay.destroy();
+  }
+};
+
+Object.defineProperty(Game, 'isRunning', {
+  get() {
+    return frameHandle !== null;
+  },
+});
+
 window.addEventListener('resize', handleResize);
 window.addEventListener('orientationchange', handleResize);
 document.addEventListener('visibilitychange', handleVisibilityChange);
+
+const viewport = window.visualViewport;
 
 if (viewport) {
   viewport.addEventListener('resize', handleViewportChange);
   viewport.addEventListener('scroll', handleViewportChange);
 }
 
+function handleKeydown(event) {
+  if (event.defaultPrevented) {
+    return;
+  }
+
+  if (event.key === 'e' || event.key === 'E') {
+    if (event.metaKey || event.ctrlKey || event.altKey) {
+      return;
+    }
+
+    if (isFormField(event.target)) {
+      return;
+    }
+
+    Game.toggleEraser();
+  }
+}
+
+window.addEventListener('keydown', handleKeydown);
+
+const ui = initializeUI(Game);
+Game.ui = ui;
+
+renderer.resize(world);
+renderer.draw(world);
+updateDebugOverlay();
+
 start();
 
-const Game = {
-  elements,
-  simulation,
-  renderer,
-  ui,
-  start,
-  stop,
-  destroy() {
-    stop();
-    window.removeEventListener('resize', handleResize);
-    window.removeEventListener('orientationchange', handleResize);
-    document.removeEventListener('visibilitychange', handleVisibilityChange);
-    if (viewport) {
-      viewport.removeEventListener('resize', handleViewportChange);
-      viewport.removeEventListener('scroll', handleViewportChange);
+Promise.resolve(runSelfChecks())
+  .then((result) => {
+    if (!result || typeof result !== 'object') {
+      console.error('❌ Phase 0–1 checks failed: Self-check did not return a result');
+      return;
     }
-    ui.destroy();
-  },
-  get isRunning() {
-    return frameHandle !== null;
-  },
-};
+
+    if (result.ok) {
+      console.log('✅ Phase 0–1 checks passed');
+    } else {
+      const lines = ['❌ Phase 0–1 checks failed:'];
+      for (const failure of result.failures) {
+        lines.push(String(failure));
+      }
+      console.error(lines.join('\n'));
+    }
+
+    if (result.phase2) {
+      if (result.ok && result.phase2.ok) {
+        console.log('✅ Phase 2 ready');
+      } else {
+        const lines = ['❌ Phase 2 regressions:'];
+        const issues = result.phase2.failures && result.phase2.failures.length
+          ? result.phase2.failures
+          : ['Unknown regression'];
+        for (const failure of issues) {
+          lines.push(String(failure));
+        }
+        console.error(lines.join('\n'));
+      }
+    }
+  })
+  .catch((error) => {
+    console.error('❌ Phase 0–1 checks failed:', error);
+  });
+
+function installQC() {
+  const helper = {
+    paintDot(x, y) {
+      Game.paintAtWorld(Number(x), Number(y), 0, SAND);
+    },
+    paintLine(x0, y0, x1, y1) {
+      const startX = Number(x0);
+      const startY = Number(y0);
+      const endX = Number(x1);
+      const endY = Number(y1);
+
+      if (!Number.isFinite(startX) || !Number.isFinite(startY) || !Number.isFinite(endX) || !Number.isFinite(endY)) {
+        return;
+      }
+
+      const dx = endX - startX;
+      const dy = endY - startY;
+      const steps = Math.max(Math.abs(dx), Math.abs(dy), 1);
+
+      for (let step = 0; step <= steps; step += 1) {
+        const t = steps === 0 ? 0 : step / steps;
+        const px = startX + dx * t;
+        const py = startY + dy * t;
+        Game.paintAtWorld(px, py);
+      }
+    },
+    togglePause() {
+      Game.togglePause();
+      return Game.state.paused;
+    },
+    clear() {
+      Game.clearWorld();
+    },
+    setBrush(size) {
+      Game.setBrushSize(size);
+      return Game.state.brushSize;
+    },
+    setElement(id) {
+      Game.setCurrentElementId(id);
+      return Game.state.currentElementId;
+    },
+    toggleEraser() {
+      Game.toggleEraser();
+      return Game.state.erasing;
+    },
+  };
+
+  const hostname = (window.location && window.location.hostname) || '';
+  const likelyProduction =
+    window.location.protocol !== 'file:' &&
+    hostname !== '' &&
+    !/localhost|127\.0\.0\.1|0\.0\.0\.0/i.test(hostname);
+
+  if (likelyProduction) {
+    Object.defineProperty(window, 'QC', {
+      value: undefined,
+      configurable: true,
+    });
+  } else {
+    Object.defineProperty(window, 'QC', {
+      value: helper,
+      writable: false,
+      configurable: true,
+    });
+  }
+}
+
+installQC();
 
 window.Game = Game;

--- a/src/selfcheck.js
+++ b/src/selfcheck.js
@@ -1,0 +1,383 @@
+import { createWorld } from './sim.js';
+import { ELEMENTS, EMPTY, WALL, SAND } from './elements.js';
+
+function normalizeMetaContent(value) {
+  return (value || '')
+    .split(',')
+    .map((part) => part.trim().toLowerCase())
+    .filter(Boolean);
+}
+
+function contentsMatch(expectedParts, actualParts) {
+  return expectedParts.every((part) => actualParts.includes(part));
+}
+
+async function runCheck(fn, bucket) {
+  try {
+    const result = await fn();
+    if (typeof result === 'string' && result.length > 0) {
+      bucket.push(result);
+    }
+  } catch (error) {
+    bucket.push(error?.message || String(error));
+  }
+}
+
+async function verifyRenderLoop() {
+  return new Promise((resolve) => {
+    let resolved = false;
+    let frames = 0;
+    const start = performance.now();
+
+    function finish(message) {
+      if (resolved) {
+        return;
+      }
+      resolved = true;
+      resolve(message);
+    }
+
+    function step() {
+      frames += 1;
+
+      if (frames >= 2) {
+        finish(null);
+        return;
+      }
+
+      if (performance.now() - start > 300) {
+        finish('Render loop did not advance within 300 ms.');
+        return;
+      }
+
+      window.requestAnimationFrame(step);
+    }
+
+    window.requestAnimationFrame(step);
+
+    setTimeout(() => {
+      finish('Render loop did not advance within 300 ms.');
+    }, 320);
+  });
+}
+
+function compareBuffers(before, after) {
+  if (!before || !after) {
+    return false;
+  }
+
+  const length = Math.min(before.length, after.length);
+
+  for (let i = 0; i < length; i += 1) {
+    if (before[i] !== after[i]) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+export async function runSelfChecks() {
+  const failures = [];
+  const phase2Failures = [];
+
+  await runCheck(() => {
+    if (!window.Game || typeof window.Game !== 'object') {
+      return 'window.Game is missing or not an object.';
+    }
+    return null;
+  }, failures);
+
+  await runCheck(() => {
+    const meta = document.querySelector('meta[name="viewport"]');
+    if (!meta) {
+      return 'Viewport meta tag is missing.';
+    }
+
+    const expected = [
+      'width=device-width',
+      'initial-scale=1',
+      'maximum-scale=1',
+      'user-scalable=no',
+    ];
+    const actualParts = normalizeMetaContent(meta.getAttribute('content'));
+
+    if (!contentsMatch(expected, actualParts)) {
+      return 'Viewport meta content must include width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no.';
+    }
+
+    return null;
+  }, failures);
+
+  await runCheck(() => {
+    const canvas = document.getElementById('game');
+
+    if (!(canvas instanceof HTMLCanvasElement)) {
+      return 'Main canvas #game was not found.';
+    }
+
+    if (canvas.width <= 0 || canvas.height <= 0) {
+      return 'Canvas #game must have a positive width and height.';
+    }
+
+    const root = document.documentElement;
+    const body = document.body;
+    const tolerance = 1;
+
+    const rootScrollable =
+      root.scrollHeight - root.clientHeight > tolerance ||
+      root.scrollWidth - root.clientWidth > tolerance;
+    const bodyScrollable =
+      body.scrollHeight - body.clientHeight > tolerance ||
+      body.scrollWidth - body.clientWidth > tolerance;
+
+    if (rootScrollable || bodyScrollable) {
+      return 'Document should not have scrollbars when the game canvas fills the viewport.';
+    }
+
+    return null;
+  }, failures);
+
+  await runCheck(async () => {
+    if (typeof window.requestAnimationFrame !== 'function') {
+      return 'requestAnimationFrame is unavailable.';
+    }
+
+    return await verifyRenderLoop();
+  }, failures);
+
+  await runCheck(() => {
+    if (typeof createWorld !== 'function') {
+      return 'createWorld is not a function.';
+    }
+
+    const testWorld = createWorld(8, 8);
+
+    if (!testWorld || typeof testWorld !== 'object') {
+      return 'createWorld did not return a valid world object.';
+    }
+
+    if (typeof testWorld.width !== 'number' || typeof testWorld.height !== 'number') {
+      return 'World dimensions must be numeric.';
+    }
+
+    if (!(testWorld.cells instanceof Uint16Array)) {
+      return 'world.cells must be a Uint16Array.';
+    }
+
+    if (!(testWorld.flags instanceof Uint8Array)) {
+      return 'world.flags must be a Uint8Array.';
+    }
+
+    return null;
+  }, failures);
+
+  await runCheck(() => {
+    const world = createWorld(4, 4);
+
+    if (typeof world.idx !== 'function' || typeof world.inBounds !== 'function') {
+      return 'World helper functions idx and inBounds must exist.';
+    }
+
+    try {
+      if (world.idx(1, 0) !== 1) {
+        return 'idx(1, 0) should equal 1.';
+      }
+    } catch (error) {
+      return `idx(1, 0) threw an error: ${error?.message || error}`;
+    }
+
+    if (world.inBounds(0, 0) !== true) {
+      return 'inBounds(0, 0) should return true.';
+    }
+
+    if (world.inBounds(-1, 0) !== false) {
+      return 'inBounds(-1, 0) should return false.';
+    }
+
+    if (world.inBounds(world.width, 0) !== false) {
+      return 'inBounds(width, 0) should return false.';
+    }
+
+    return null;
+  }, failures);
+
+  await runCheck(() => {
+    const game = window.Game;
+
+    if (!game) {
+      return 'Game object is unavailable.';
+    }
+
+    const elements = game.ELEMENTS || ELEMENTS;
+    const palette = window.PALETTE || game.PALETTE;
+    const emptyId = window.EMPTY ?? game.constants?.EMPTY ?? elements.EMPTY;
+    const wallId = window.WALL ?? game.constants?.WALL ?? elements.WALL;
+    const sandId = window.SAND ?? game.constants?.SAND ?? elements.SAND;
+
+    if (!elements) {
+      return 'ELEMENTS constants are unavailable.';
+    }
+
+    if (typeof emptyId !== 'number' || typeof wallId !== 'number' || typeof sandId !== 'number') {
+      return 'EMPTY, WALL, and SAND constants must be numbers.';
+    }
+
+    if (!palette) {
+      return 'PALETTE is unavailable.';
+    }
+
+    const wallColor = palette[wallId];
+    const sandColor = palette[sandId];
+
+    const validSwatch = (swatch) =>
+      Array.isArray(swatch) &&
+      swatch.length === 4 &&
+      swatch.every((value) => Number.isInteger(value) && value >= 0 && value <= 255);
+
+    if (!validSwatch(wallColor) || !validSwatch(sandColor)) {
+      return 'PALETTE[WALL] and PALETTE[SAND] must be [r, g, b, a] arrays.';
+    }
+
+    return null;
+  }, failures);
+
+  await runCheck(() => {
+    const game = window.Game;
+
+    if (!game || !game.renderer || typeof game.renderer.draw !== 'function') {
+      return 'Game.renderer.draw is unavailable.';
+    }
+
+    const originalWorld = game.simulation?.state?.world || null;
+    const tempWorld = createWorld(16, 16);
+
+    try {
+      const idx = tempWorld.idx;
+      tempWorld.cells[idx(1, 1)] = WALL;
+      tempWorld.cells[idx(2, 2)] = SAND;
+      tempWorld.cells[idx(3, 3)] = SAND;
+      game.renderer.draw(tempWorld);
+    } catch (error) {
+      return `Renderer dry run failed: ${error?.message || error}`;
+    } finally {
+      if (originalWorld) {
+        game.renderer.resize(originalWorld);
+        game.renderer.draw(originalWorld);
+      }
+    }
+
+    return null;
+  }, failures);
+
+  await runCheck(() => {
+    const game = window.Game;
+
+    if (!game || !game.renderer || typeof game.renderer.draw !== 'function') {
+      return 'Game.renderer.draw is unavailable for integrity testing.';
+    }
+
+    const originalWorld = game.simulation?.state?.world || null;
+    const tempWorld = createWorld(8, 8);
+
+    try {
+      tempWorld.cells.fill(EMPTY);
+      tempWorld.flags.fill(0);
+      game.renderer.draw(tempWorld);
+      const before = game.renderer.readPixels();
+      const idx = tempWorld.idx;
+      tempWorld.cells[idx(2, 2)] = SAND;
+      game.renderer.draw(tempWorld);
+      const after = game.renderer.readPixels();
+
+      if (!compareBuffers(before, after)) {
+        return 'Painting SAND into the world did not modify the canvas pixels.';
+      }
+    } catch (error) {
+      return `Renderer paint integrity check failed: ${error?.message || error}`;
+    } finally {
+      if (originalWorld) {
+        game.renderer.resize(originalWorld);
+        game.renderer.draw(originalWorld);
+      }
+    }
+
+    return null;
+  }, failures);
+
+  const baseOk = failures.length === 0;
+
+  await runCheck(async () => {
+    const game = window.Game;
+
+    if (!game || !game.ui || !game.ui.elements || !game.ui.elements.pauseToggle) {
+      return 'Pause toggle button is unavailable for UI test.';
+    }
+
+    const pauseButton = game.ui.elements.pauseToggle;
+    const initialState = Boolean(game.state?.paused);
+
+    pauseButton.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    await new Promise((resolve) => window.requestAnimationFrame(resolve));
+
+    if (Boolean(game.state?.paused) === initialState) {
+      return 'Pause toggle did not update Game.state.paused.';
+    }
+
+    pauseButton.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    await new Promise((resolve) => window.requestAnimationFrame(resolve));
+
+    if (Boolean(game.state?.paused) !== initialState) {
+      game.togglePause(initialState);
+    }
+
+    return null;
+  }, phase2Failures);
+
+  await runCheck(async () => {
+    const game = window.Game;
+
+    if (!game || !game.ui || !game.ui.elements || !game.ui.elements.brushSize) {
+      return 'Brush size control is unavailable for binding check.';
+    }
+
+    const slider = game.ui.elements.brushSize;
+    const originalValue = slider.value;
+
+    slider.value = '13';
+    slider.dispatchEvent(new Event('input', { bubbles: true }));
+    await new Promise((resolve) => window.requestAnimationFrame(resolve));
+
+    if (game.state?.brushSize !== 13) {
+      slider.value = originalValue;
+      slider.dispatchEvent(new Event('input', { bubbles: true }));
+      return 'Brush size control did not update Game.state.brushSize to 13.';
+    }
+
+    slider.value = originalValue;
+    slider.dispatchEvent(new Event('input', { bubbles: true }));
+    await new Promise((resolve) => window.requestAnimationFrame(resolve));
+
+    return null;
+  }, phase2Failures);
+
+  const phase2Ok = baseOk && phase2Failures.length === 0;
+
+  const result = {
+    ok: baseOk,
+    failures,
+    phase2: {
+      ok: phase2Ok,
+      failures: phase2Failures,
+    },
+  };
+
+  console.info(
+    '[SelfCheck]',
+    baseOk ? 'Phase 0–1 OK' : `Phase 0–1 failures: ${failures.length}`,
+    '|',
+    phase2Ok ? 'Phase 2 OK' : `Phase 2 issues: ${phase2Failures.length}`,
+  );
+
+  return result;
+}

--- a/src/sim.js
+++ b/src/sim.js
@@ -74,6 +74,78 @@ export function createWorld(width, height) {
   };
 }
 
+export function paintCircle(world, x, y, radius, elementId) {
+  if (!world || !world.cells || !world.flags) {
+    return 0;
+  }
+
+  const width = Number(world.width) || 0;
+  const height = Number(world.height) || 0;
+
+  if (width <= 0 || height <= 0) {
+    return 0;
+  }
+
+  const cells = world.cells;
+  const centerX = Math.trunc(Number.isFinite(x) ? x : NaN);
+  const centerY = Math.trunc(Number.isFinite(y) ? y : NaN);
+
+  if (!Number.isFinite(centerX) || !Number.isFinite(centerY)) {
+    return 0;
+  }
+
+  let effectiveRadius = Math.trunc(Number.isFinite(radius) ? radius : 0);
+
+  if (effectiveRadius < 0) {
+    effectiveRadius = 0;
+  }
+
+  const squaredRadius = effectiveRadius * effectiveRadius;
+  let changed = 0;
+
+  if (effectiveRadius === 0) {
+    if (centerX >= 0 && centerX < width && centerY >= 0 && centerY < height) {
+      const index = centerY * width + centerX;
+      if (cells[index] !== elementId) {
+        cells[index] = elementId;
+        changed += 1;
+      }
+    }
+    return changed;
+  }
+
+  for (let offsetY = -effectiveRadius; offsetY <= effectiveRadius; offsetY += 1) {
+    const sampleY = centerY + offsetY;
+
+    if (sampleY < 0 || sampleY >= height) {
+      continue;
+    }
+
+    const ySquared = offsetY * offsetY;
+    const maxOffsetX = Math.floor(Math.sqrt(Math.max(squaredRadius - ySquared, 0)));
+    let startX = centerX - maxOffsetX;
+    let endX = centerX + maxOffsetX;
+
+    if (startX < 0) {
+      startX = 0;
+    }
+
+    if (endX >= width) {
+      endX = width - 1;
+    }
+
+    for (let sampleX = startX; sampleX <= endX; sampleX += 1) {
+      const index = sampleY * width + sampleX;
+      if (cells[index] !== elementId) {
+        cells[index] = elementId;
+        changed += 1;
+      }
+    }
+  }
+
+  return changed;
+}
+
 export function createSimulation(options = {}) {
   const width = normalizeDimension(options.width, DEFAULT_WORLD_WIDTH);
   const height = normalizeDimension(options.height, DEFAULT_WORLD_HEIGHT);

--- a/src/ui.js
+++ b/src/ui.js
@@ -1,41 +1,431 @@
-export function initializeUI(canvas) {
-  let lastTouchEnd = 0;
+const STYLE_ID = 'powder-ui-style';
+const TOOLBAR_ID = 'powder-toolbar';
+const MODAL_ID = 'powder-element-modal';
 
-  const preventIfCancelable = (event) => {
-    if (event.cancelable) {
-      event.preventDefault();
+function injectStyles() {
+  if (document.getElementById(STYLE_ID)) {
+    return;
+  }
+
+  const style = document.createElement('style');
+  style.id = STYLE_ID;
+  style.textContent = `
+    #app {
+      position: relative;
     }
-  };
 
-  const handleTouchMove = (event) => {
-    if (event.touches.length > 1) {
-      preventIfCancelable(event);
+    #${TOOLBAR_ID} {
+      position: fixed;
+      top: 0;
+      left: 0;
+      right: 0;
+      display: flex;
+      align-items: center;
+      gap: 0.5rem;
+      padding: 0.5rem 1rem;
+      background: rgba(10, 15, 26, 0.92);
+      color: #f5f7ff;
+      z-index: 1000;
+      font-family: inherit;
+      box-shadow: 0 4px 18px rgba(0, 0, 0, 0.35);
+      backdrop-filter: blur(12px);
     }
-  };
 
-  const handleTouchStart = (event) => {
-    if (event.touches.length > 1) {
-      preventIfCancelable(event);
+    #${TOOLBAR_ID} * {
+      font-family: inherit;
     }
-  };
 
-  const handleTouchEnd = (event) => {
-    const now = performance.now();
-    if (now - lastTouchEnd <= 300) {
-      preventIfCancelable(event);
+    #${TOOLBAR_ID} button,
+    #${TOOLBAR_ID} .ui-chip,
+    #${TOOLBAR_ID} .ui-brush {
+      min-height: 44px;
+      border: none;
+      border-radius: 12px;
+      background: rgba(34, 43, 67, 0.78);
+      color: inherit;
+      font-size: 0.9rem;
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      padding: 0 0.85rem;
+      gap: 0.5rem;
+      box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.06);
+      transition: background 0.2s ease;
     }
-    lastTouchEnd = now;
-  };
 
-  canvas.addEventListener('touchstart', handleTouchStart, { passive: false });
-  canvas.addEventListener('touchmove', handleTouchMove, { passive: false });
-  canvas.addEventListener('touchend', handleTouchEnd, { passive: false });
+    #${TOOLBAR_ID} button {
+      cursor: pointer;
+    }
+
+    #${TOOLBAR_ID} button:focus-visible,
+    #${TOOLBAR_ID} input:focus-visible {
+      outline: 2px solid rgba(118, 154, 255, 0.9);
+      outline-offset: 2px;
+    }
+
+    #${TOOLBAR_ID} button.active {
+      background: rgba(84, 112, 255, 0.88);
+      color: #ffffff;
+      box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.18);
+    }
+
+    #${TOOLBAR_ID} .ui-chip {
+      cursor: default;
+    }
+
+    #${TOOLBAR_ID} .chip-color {
+      width: 20px;
+      height: 20px;
+      border-radius: 6px;
+      box-shadow: 0 0 0 1px rgba(255, 255, 255, 0.3);
+      background: rgba(255, 255, 255, 0.12);
+    }
+
+    #${TOOLBAR_ID} .chip-name {
+      font-weight: 600;
+      letter-spacing: 0.02em;
+    }
+
+    #${TOOLBAR_ID} .ui-brush {
+      padding: 0 0.85rem;
+      gap: 0.75rem;
+    }
+
+    #${TOOLBAR_ID} .ui-brush span {
+      font-size: 0.8rem;
+      opacity: 0.8;
+    }
+
+    #${TOOLBAR_ID} input[type='range'] {
+      width: 140px;
+      accent-color: #7088ff;
+    }
+
+    #${MODAL_ID} {
+      position: fixed;
+      inset: 0;
+      display: none;
+      align-items: center;
+      justify-content: center;
+      background: rgba(5, 8, 14, 0.55);
+      backdrop-filter: blur(6px);
+      z-index: 1100;
+    }
+
+    #${MODAL_ID}[data-open='true'] {
+      display: flex;
+    }
+
+    #${MODAL_ID} .ui-modal-panel {
+      background: rgba(18, 25, 40, 0.96);
+      color: #f7f9ff;
+      border-radius: 18px;
+      padding: 1.5rem;
+      min-width: 220px;
+      max-width: min(90vw, 360px);
+      text-align: center;
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+      box-shadow: 0 18px 42px rgba(0, 0, 0, 0.45);
+    }
+
+    #${MODAL_ID} .ui-modal-panel button {
+      align-self: center;
+      min-width: 140px;
+    }
+  `;
+
+  document.head.appendChild(style);
+}
+
+function stopEventPropagation(event) {
+  event.stopPropagation();
+}
+
+function applyLayout(canvas) {
+  const app = document.getElementById('app');
+
+  if (app) {
+    app.style.display = 'flex';
+    app.style.flexDirection = 'column';
+    app.style.alignItems = 'stretch';
+    app.style.justifyContent = 'flex-start';
+    app.style.height = '100%';
+    app.style.width = '100%';
+    app.style.boxSizing = 'border-box';
+  }
+
+  if (canvas) {
+    canvas.style.flex = '1 1 auto';
+    canvas.style.width = '100%';
+    canvas.style.height = '100%';
+    canvas.style.display = 'block';
+  }
+}
+
+export function initializeUI(game) {
+  if (!game || !game.elements || !game.elements.canvas) {
+    throw new Error('initializeUI expects a Game reference with canvas elements.');
+  }
+
+  injectStyles();
+
+  const canvas = game.elements.canvas;
+  applyLayout(canvas);
+
+  const toolbar = document.createElement('div');
+  toolbar.id = TOOLBAR_ID;
+  toolbar.setAttribute('role', 'toolbar');
+  toolbar.dataset.uiToolbar = 'true';
+
+  const chip = document.createElement('div');
+  chip.className = 'ui-chip';
+  const chipColor = document.createElement('span');
+  chipColor.className = 'chip-color';
+  const chipName = document.createElement('span');
+  chipName.className = 'chip-name';
+  chip.append(chipColor, chipName);
+
+  const elementButton = document.createElement('button');
+  elementButton.type = 'button';
+  elementButton.className = 'ui-button elements';
+  elementButton.textContent = 'Elements';
+
+  const pauseButton = document.createElement('button');
+  pauseButton.type = 'button';
+  pauseButton.className = 'ui-button pause';
+  pauseButton.textContent = 'Pause';
+
+  const eraserButton = document.createElement('button');
+  eraserButton.type = 'button';
+  eraserButton.className = 'ui-button eraser';
+  eraserButton.textContent = 'Eraser';
+
+  const clearButton = document.createElement('button');
+  clearButton.type = 'button';
+  clearButton.className = 'ui-button clear';
+  clearButton.textContent = 'Clear';
+
+  const brushWrapper = document.createElement('label');
+  brushWrapper.className = 'ui-brush';
+  brushWrapper.setAttribute('for', 'brush-size-control');
+  const brushLabel = document.createElement('span');
+  brushLabel.textContent = 'Brush';
+  const brushInput = document.createElement('input');
+  brushInput.type = 'range';
+  brushInput.min = '1';
+  brushInput.max = '20';
+  brushInput.step = '1';
+  brushInput.value = String(game.state?.brushSize ?? 4);
+  brushInput.id = 'brush-size-control';
+  brushWrapper.append(brushLabel, brushInput);
+
+  toolbar.append(chip, elementButton, pauseButton, eraserButton, clearButton, brushWrapper);
+  document.body.appendChild(toolbar);
+
+  const modal = document.createElement('div');
+  modal.id = MODAL_ID;
+  modal.setAttribute('aria-hidden', 'true');
+
+  const modalPanel = document.createElement('div');
+  modalPanel.className = 'ui-modal-panel';
+  const modalHeading = document.createElement('h2');
+  modalHeading.textContent = 'Elements';
+  const modalBody = document.createElement('p');
+  modalBody.textContent = 'Element selection coming soon.';
+  const modalClose = document.createElement('button');
+  modalClose.type = 'button';
+  modalClose.textContent = 'Close';
+
+  modalPanel.append(modalHeading, modalBody, modalClose);
+  modal.append(modalPanel);
+  document.body.appendChild(modal);
+
+  const stopPropagationTargets = [
+    toolbar,
+    elementButton,
+    pauseButton,
+    eraserButton,
+    clearButton,
+    brushWrapper,
+    brushInput,
+    modal,
+    modalPanel,
+    modalClose,
+  ];
+
+  const pointerEvents = [
+    'touchstart',
+    'touchmove',
+    'touchend',
+    'pointerdown',
+    'pointermove',
+    'pointerup',
+    'mousedown',
+    'mousemove',
+    'mouseup',
+    'click',
+  ];
+
+  for (const target of stopPropagationTargets) {
+    for (const type of pointerEvents) {
+      target.addEventListener(type, stopEventPropagation, { capture: true });
+    }
+  }
+
+  let modalOpen = false;
+
+  function setModalOpen(next) {
+    modalOpen = Boolean(next);
+    modal.setAttribute('data-open', modalOpen ? 'true' : 'false');
+    modal.setAttribute('aria-hidden', modalOpen ? 'false' : 'true');
+  }
+
+  elementButton.addEventListener('click', () => {
+    setModalOpen(true);
+  });
+
+  modalClose.addEventListener('click', () => {
+    setModalOpen(false);
+  });
+
+  modal.addEventListener('click', (event) => {
+    if (event.target === modal) {
+      setModalOpen(false);
+    }
+  });
+
+  pauseButton.addEventListener('click', () => {
+    if (typeof game.togglePause === 'function') {
+      game.togglePause();
+    }
+  });
+
+  eraserButton.addEventListener('click', () => {
+    if (typeof game.toggleEraser === 'function') {
+      game.toggleEraser();
+    }
+  });
+
+  clearButton.addEventListener('click', () => {
+    if (typeof game.clearWorld === 'function') {
+      game.clearWorld();
+    }
+  });
+
+  brushInput.addEventListener('input', () => {
+    if (typeof game.setBrushSize === 'function') {
+      game.setBrushSize(Number(brushInput.value));
+    }
+  });
+
+  let lastKnownState = null;
+
+  function formatElementName(elementId) {
+    if (typeof game.getElementName === 'function') {
+      return game.getElementName(elementId);
+    }
+
+    if (game.elements && game.elements.names && game.elements.names[elementId]) {
+      return game.elements.names[elementId];
+    }
+
+    return `Element ${elementId}`;
+  }
+
+  function updateChipColor(elementId) {
+    const palette = game.PALETTE || {};
+    const swatch = palette[elementId];
+
+    if (Array.isArray(swatch)) {
+      const [r, g, b, a = 255] = swatch;
+      chipColor.style.backgroundColor = `rgba(${r}, ${g}, ${b}, ${a / 255})`;
+    } else {
+      chipColor.style.backgroundColor = 'rgba(255, 255, 255, 0.2)';
+    }
+  }
+
+  function refresh(state = game.state) {
+    if (!state || state === lastKnownState) {
+      return;
+    }
+
+    chipName.textContent = formatElementName(state.currentElementId ?? 0);
+    updateChipColor(state.currentElementId ?? 0);
+
+    pauseButton.classList.toggle('active', Boolean(state.paused));
+    pauseButton.textContent = state.paused ? 'Resume' : 'Pause';
+
+    eraserButton.classList.toggle('active', Boolean(state.erasing));
+
+    if (Number(brushInput.value) !== Number(state.brushSize)) {
+      brushInput.value = String(state.brushSize);
+    }
+
+    lastKnownState = state;
+  }
+
+  refresh(game.state);
+
+  const unsubscribe = typeof game.onStateChange === 'function'
+    ? game.onStateChange((state) => {
+        refresh(state);
+      })
+    : null;
+
+  function updateToolbarMetrics() {
+    const rect = toolbar.getBoundingClientRect();
+    const height = Number.isFinite(rect.height) ? rect.height : toolbar.offsetHeight;
+
+    if (Number.isFinite(height)) {
+      if (game.layout) {
+        game.layout.toolbarHeight = height;
+      }
+
+      const app = document.getElementById('app');
+      if (app) {
+        app.style.paddingTop = `${height}px`;
+      }
+
+      if (typeof game.renderer?.resize === 'function' && game.simulation?.state?.world) {
+        game.renderer.resize(game.simulation.state.world);
+      }
+    }
+  }
+
+  updateToolbarMetrics();
+  window.addEventListener('resize', updateToolbarMetrics);
+  window.addEventListener('orientationchange', updateToolbarMetrics);
 
   return {
     destroy() {
-      canvas.removeEventListener('touchstart', handleTouchStart);
-      canvas.removeEventListener('touchmove', handleTouchMove);
-      canvas.removeEventListener('touchend', handleTouchEnd);
+      for (const target of stopPropagationTargets) {
+        for (const type of pointerEvents) {
+          target.removeEventListener(type, stopEventPropagation, { capture: true });
+        }
+      }
+
+      window.removeEventListener('resize', updateToolbarMetrics);
+      window.removeEventListener('orientationchange', updateToolbarMetrics);
+
+      if (unsubscribe) {
+        unsubscribe();
+      }
+
+      toolbar.remove();
+      modal.remove();
+    },
+    refresh,
+    elements: {
+      toolbar,
+      pauseToggle: pauseButton,
+      brushSize: brushInput,
+      eraserToggle: eraserButton,
+      elementButton,
+    },
+    isElementModalOpen() {
+      return modalOpen;
     },
   };
 }


### PR DESCRIPTION
## Summary
- add a self-check harness that verifies Phase 0–2 requirements and logs consolidated results
- rebuild the main game loop with touch/mouse painting, brush logic, throttling guardrails, and a debug overlay
- introduce a fixed toolbar UI with pause, clear, brush controls, eraser toggle, and QC helpers for QA

## Testing
- not run (browser-based project)

------
https://chatgpt.com/codex/tasks/task_e_68ca31f172a0832ba838f4d6c7ab29e2