### PR TITLE
Add water element and expanded self-check harness

### DIFF
--- a/src/elements.js
+++ b/src/elements.js
@@ -1,8 +1,65 @@
-export const ELEMENTS = Object.freeze({
-  EMPTY: 0,
-  WALL: 1,
-  SAND: 2,
+export const EMPTY = 0;
+export const WALL = 1;
+export const SAND = 2;
+export const WATER = 3;
+
+export const ELEMENT_IDS = Object.freeze({
+  EMPTY,
+  WALL,
+  SAND,
+  WATER,
 });
+
+export const ELEMENTS = [];
+
+ELEMENTS[EMPTY] = Object.freeze({
+  id: EMPTY,
+  name: 'Empty',
+  state: 'void',
+  density: 0,
+  immovable: true,
+  viscosity: 0,
+  lateralRunMax: 0,
+  buoyancy: 0,
+});
+
+ELEMENTS[WALL] = Object.freeze({
+  id: WALL,
+  name: 'Wall',
+  state: 'solid',
+  density: 10000,
+  immovable: true,
+  viscosity: 0,
+  lateralRunMax: 0,
+  buoyancy: 0,
+});
+
+ELEMENTS[SAND] = Object.freeze({
+  id: SAND,
+  name: 'Sand',
+  state: 'solid',
+  density: 1700,
+  immovable: false,
+  viscosity: 4,
+  lateralRunMax: 1,
+  buoyancy: -1,
+});
+
+ELEMENTS[WATER] = Object.freeze({
+  id: WATER,
+  name: 'Water',
+  state: 'liquid',
+  density: 1000,
+  immovable: false,
+  viscosity: 1,
+  lateralRunMax: 2,
+  buoyancy: 1,
+});
+
+ELEMENTS.EMPTY = EMPTY;
+ELEMENTS.WALL = WALL;
+ELEMENTS.SAND = SAND;
+ELEMENTS.WATER = WATER;
 
 export const PALETTE = new Uint8ClampedArray([
   // EMPTY
@@ -11,11 +68,9 @@ export const PALETTE = new Uint8ClampedArray([
   54, 57, 66, 255,
   // SAND
   237, 201, 81, 255,
+  // WATER
+  64, 128, 255, 255,
 ]);
-
-export const EMPTY = ELEMENTS.EMPTY;
-export const WALL = ELEMENTS.WALL;
-export const SAND = ELEMENTS.SAND;
 
 export function createGameElements() {
   const canvas = document.getElementById('game-canvas');

--- a/src/selfcheck.js
+++ b/src/selfcheck.js
@@ -1,5 +1,5 @@
-import { createWorld } from './sim.js';
-import { ELEMENTS, EMPTY, WALL, SAND } from './elements.js';
+import { createWorld, beginTick, endTick, step as stepWorld } from './sim.js';
+import { ELEMENTS, EMPTY, WALL, SAND, WATER } from './elements.js';
 
 function normalizeMetaContent(value) {
   return (value || '')
@@ -25,39 +25,27 @@ async function runCheck(fn, bucket) {
 
 async function verifyRenderLoop() {
   return new Promise((resolve) => {
-    let resolved = false;
-    let frames = 0;
-    const start = performance.now();
+    const game = window.Game;
+    const startFrame = Number(game?.metrics?.frameCount ?? 0);
+    const startTime = performance.now();
 
-    function finish(message) {
-      if (resolved) {
+    function check() {
+      const currentFrame = Number(game?.metrics?.frameCount ?? 0);
+
+      if (currentFrame > startFrame) {
+        resolve(null);
         return;
       }
-      resolved = true;
-      resolve(message);
+
+      if (performance.now() - startTime > 300) {
+        resolve('Render loop did not advance within 300 ms.');
+        return;
+      }
+
+      window.requestAnimationFrame(check);
     }
 
-    function step() {
-      frames += 1;
-
-      if (frames >= 2) {
-        finish(null);
-        return;
-      }
-
-      if (performance.now() - start > 300) {
-        finish('Render loop did not advance within 300 ms.');
-        return;
-      }
-
-      window.requestAnimationFrame(step);
-    }
-
-    window.requestAnimationFrame(step);
-
-    setTimeout(() => {
-      finish('Render loop did not advance within 300 ms.');
-    }, 320);
+    window.requestAnimationFrame(check);
   });
 }
 
@@ -66,9 +54,11 @@ function compareBuffers(before, after) {
     return false;
   }
 
-  const length = Math.min(before.length, after.length);
+  if (before.length !== after.length) {
+    return false;
+  }
 
-  for (let i = 0; i < length; i += 1) {
+  for (let i = 0; i < before.length; i += 1) {
     if (before[i] !== after[i]) {
       return true;
     }
@@ -77,9 +67,74 @@ function compareBuffers(before, after) {
   return false;
 }
 
+function cloneGameStateForSimulation() {
+  const game = window.Game;
+
+  if (game && game.state) {
+    return {
+      seed: game.state.seed ?? 0,
+      frame: game.state.frame ?? 0,
+    };
+  }
+
+  return { seed: 0, frame: 0 };
+}
+
+function runSimulationSteps(world, steps, state) {
+  if (!world || steps <= 0) {
+    return;
+  }
+
+  const stepState = state ?? { seed: 0, frame: 0 };
+  const context = { state: stepState };
+
+  for (let i = 0; i < steps; i += 1) {
+    beginTick(world);
+    stepWorld(world, context);
+    endTick(world);
+    stepState.frame = (stepState.frame ?? 0) + 1;
+  }
+}
+
+function findElementPositions(world, elementId) {
+  const positions = [];
+
+  if (!world || !world.cells || !world.width) {
+    return positions;
+  }
+
+  const width = world.width;
+
+  for (let index = 0; index < world.cells.length; index += 1) {
+    if (world.cells[index] === elementId) {
+      positions.push({
+        index,
+        x: index % width,
+        y: Math.floor(index / width),
+      });
+    }
+  }
+
+  return positions;
+}
+
+function arraysEqual(a, b) {
+  if (!a || !b || a.length !== b.length) {
+    return false;
+  }
+
+  for (let i = 0; i < a.length; i += 1) {
+    if (a[i] !== b[i]) {
+      return false;
+    }
+  }
+
+  return true;
+}
 export async function runSelfChecks() {
   const failures = [];
   const phase2Failures = [];
+  const phase3Failures = [];
 
   await runCheck(() => {
     if (!window.Game || typeof window.Game !== 'object') {
@@ -169,6 +224,10 @@ export async function runSelfChecks() {
       return 'world.flags must be a Uint8Array.';
     }
 
+    if (!(testWorld.lastMoveDir instanceof Int8Array)) {
+      return 'world.lastMoveDir must be an Int8Array.';
+    }
+
     return null;
   }, failures);
 
@@ -209,34 +268,29 @@ export async function runSelfChecks() {
       return 'Game object is unavailable.';
     }
 
-    const elements = game.ELEMENTS || ELEMENTS;
-    const palette = window.PALETTE || game.PALETTE;
-    const emptyId = window.EMPTY ?? game.constants?.EMPTY ?? elements.EMPTY;
-    const wallId = window.WALL ?? game.constants?.WALL ?? elements.WALL;
-    const sandId = window.SAND ?? game.constants?.SAND ?? elements.SAND;
+    const elements = game.elementDefinitions || ELEMENTS;
+    const palette = game.PALETTE || {};
 
-    if (!elements) {
-      return 'ELEMENTS constants are unavailable.';
+    if (!Array.isArray(elements) || elements.length === 0) {
+      return 'Element definitions are unavailable.';
     }
 
-    if (typeof emptyId !== 'number' || typeof wallId !== 'number' || typeof sandId !== 'number') {
-      return 'EMPTY, WALL, and SAND constants must be numbers.';
+    const waterMeta = elements[WATER];
+    if (!waterMeta || typeof waterMeta.lateralRunMax !== 'number') {
+      return 'Water metadata must define lateralRunMax.';
     }
-
-    if (!palette) {
-      return 'PALETTE is unavailable.';
-    }
-
-    const wallColor = palette[wallId];
-    const sandColor = palette[sandId];
 
     const validSwatch = (swatch) =>
       Array.isArray(swatch) &&
       swatch.length === 4 &&
       swatch.every((value) => Number.isInteger(value) && value >= 0 && value <= 255);
 
-    if (!validSwatch(wallColor) || !validSwatch(sandColor)) {
-      return 'PALETTE[WALL] and PALETTE[SAND] must be [r, g, b, a] arrays.';
+    if (!validSwatch(palette[WALL]) || !validSwatch(palette[SAND])) {
+      return 'PALETTE entries for WALL and SAND must be [r, g, b, a] arrays.';
+    }
+
+    if (typeof EMPTY !== 'number' || typeof WALL !== 'number' || typeof SAND !== 'number') {
+      return 'EMPTY, WALL, and SAND constants must be numbers.';
     }
 
     return null;
@@ -283,6 +337,9 @@ export async function runSelfChecks() {
     try {
       tempWorld.cells.fill(EMPTY);
       tempWorld.flags.fill(0);
+      if (tempWorld.lastMoveDir) {
+        tempWorld.lastMoveDir.fill(0);
+      }
       game.renderer.draw(tempWorld);
       const before = game.renderer.readPixels();
       const idx = tempWorld.idx;
@@ -304,8 +361,24 @@ export async function runSelfChecks() {
 
     return null;
   }, failures);
+  await runCheck(() => {
+    const toolbar = document.getElementById('powder-toolbar');
+    if (!toolbar) {
+      return 'Toolbar element #powder-toolbar is missing.';
+    }
 
-  const baseOk = failures.length === 0;
+    const elementButton = toolbar.querySelector('button.ui-button.elements');
+    const pauseButton = toolbar.querySelector('button.ui-button.pause');
+    const clearButton = toolbar.querySelector('button.ui-button.clear');
+    const eraserButton = toolbar.querySelector('button.ui-button.eraser');
+    const brushInput = toolbar.querySelector('input[type="range"]');
+
+    if (!elementButton || !pauseButton || !clearButton || !eraserButton || !brushInput) {
+      return 'Toolbar buttons (Elements, Pause, Clear, Eraser, Brush range) must exist.';
+    }
+
+    return null;
+  }, phase2Failures);
 
   await runCheck(async () => {
     const game = window.Game;
@@ -361,23 +434,301 @@ export async function runSelfChecks() {
     return null;
   }, phase2Failures);
 
-  const phase2Ok = baseOk && phase2Failures.length === 0;
+  await runCheck(async () => {
+    const game = window.Game;
+    const toolbar = document.getElementById('powder-toolbar');
+    const world = game?.simulation?.state?.world;
+
+    if (!toolbar) {
+      return 'Toolbar element is required for interaction safety test.';
+    }
+
+    if (!world || !world.cells) {
+      return 'World is unavailable for toolbar interaction test.';
+    }
+
+    const wasPaused = Boolean(game.state?.paused);
+    game.togglePause(true);
+
+    const before = new Uint16Array(world.cells);
+    toolbar.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true }));
+    await new Promise((resolve) => window.requestAnimationFrame(resolve));
+    game.togglePause(wasPaused);
+
+    if (!arraysEqual(before, world.cells)) {
+      return 'Toolbar interactions should not trigger canvas painting.';
+    }
+
+    return null;
+  }, phase2Failures);
+
+  await runCheck(() => {
+    const game = window.Game;
+    const stepSeconds = Number(game?.simulation?.state?.stepSeconds);
+
+    if (!Number.isFinite(stepSeconds)) {
+      return 'Game.simulation.state.stepSeconds must be a finite number.';
+    }
+
+    if (stepSeconds < 1 / 60 - 0.002 || stepSeconds > 1 / 20 + 0.005) {
+      return 'Simulation stepSeconds must correspond to roughly 20–60 Hz.';
+    }
+
+    return null;
+  }, phase3Failures);
+
+  await runCheck(() => {
+    const world = createWorld(6, 6);
+    const idx = world.idx;
+    world.cells[idx(2, 1)] = SAND;
+
+    const state = cloneGameStateForSimulation();
+    runSimulationSteps(world, 30, state);
+
+    const positions = findElementPositions(world, SAND);
+    if (positions.length === 0) {
+      return 'SAND disappeared during gravity test.';
+    }
+
+    if (!positions.some((pos) => pos.y > 1)) {
+      return 'SAND did not fall downward after 30 steps.';
+    }
+
+    const wallWorld = createWorld(4, 4);
+    const wallIdx = wallWorld.idx;
+    wallWorld.cells[wallIdx(1, 3)] = WALL;
+    wallWorld.cells[wallIdx(1, 0)] = SAND;
+
+    const wallState = cloneGameStateForSimulation();
+    runSimulationSteps(wallWorld, 12, wallState);
+
+    if (wallWorld.cells[wallIdx(1, 3)] !== WALL || wallWorld.cells[wallIdx(1, 2)] !== SAND) {
+      return 'SAND passed through WALL during gravity test.';
+    }
+
+    return null;
+  }, phase3Failures);
+
+  await runCheck(() => {
+    const world = createWorld(5, 6);
+    const idx = world.idx;
+    world.cells[idx(2, 0)] = SAND;
+
+    const state = cloneGameStateForSimulation();
+    let previousY = 0;
+
+    for (let step = 0; step < 3; step += 1) {
+      runSimulationSteps(world, 1, state);
+      const positions = findElementPositions(world, SAND);
+
+      if (positions.length === 0) {
+        return 'SAND disappeared during teleport guard test.';
+      }
+
+      const currentY = positions[0].y;
+      if (Math.abs(currentY - previousY) > 1) {
+        return 'SAND moved more than one row in a single tick.';
+      }
+      previousY = currentY;
+    }
+
+    return null;
+  }, phase3Failures);
+
+  await runCheck(() => {
+    const world = createWorld(4, 4);
+    const idx = world.idx;
+    world.cells[idx(1, 1)] = SAND;
+
+    const state = cloneGameStateForSimulation();
+    beginTick(world);
+
+    for (let i = 0; i < world.flags.length; i += 1) {
+      if (world.flags[i] & 1) {
+        return 'Moved flag should be clear before a simulation step.';
+      }
+    }
+
+    runSimulationSteps(world, 1, state);
+
+    let movedSet = false;
+    for (let i = 0; i < world.flags.length; i += 1) {
+      if (world.flags[i] & 1) {
+        movedSet = true;
+        break;
+      }
+    }
+
+    if (!movedSet) {
+      return 'Moved flag was not set for an active SAND cell.';
+    }
+
+    endTick(world);
+
+    for (let i = 0; i < world.flags.length; i += 1) {
+      if (world.flags[i] & 1) {
+        return 'Moved flag did not reset after endTick.';
+      }
+    }
+
+    return null;
+  }, phase3Failures);
 
   const result = {
-    ok: baseOk,
+    ok: failures.length === 0,
     failures,
     phase2: {
-      ok: phase2Ok,
+      ok: phase2Failures.length === 0,
       failures: phase2Failures,
+    },
+    phase3: {
+      ok: phase3Failures.length === 0,
+      failures: phase3Failures,
     },
   };
 
-  console.info(
-    '[SelfCheck]',
-    baseOk ? 'Phase 0–1 OK' : `Phase 0–1 failures: ${failures.length}`,
-    '|',
-    phase2Ok ? 'Phase 2 OK' : `Phase 2 issues: ${phase2Failures.length}`,
-  );
-
   return result;
+}
+export async function runSelfChecksPhase4(baseResult) {
+  const base = baseResult || (await runSelfChecks());
+  const combinedFailures = [];
+
+  if (base && !base.ok) {
+    combinedFailures.push(...base.failures);
+  }
+
+  if (base?.phase2 && !base.phase2.ok) {
+    combinedFailures.push(...base.phase2.failures);
+  }
+
+  if (base?.phase3 && !base.phase3.ok) {
+    combinedFailures.push(...base.phase3.failures);
+  }
+
+  const phase4Failures = [];
+
+  await runCheck(() => {
+    const waterMeta = ELEMENTS[WATER];
+    if (!waterMeta || typeof waterMeta.lateralRunMax !== 'number') {
+      return 'Water metadata must define lateralRunMax.';
+    }
+
+    const world = createWorld(16, 8);
+    const idx = world.idx;
+
+    for (let x = 0; x < world.width; x += 1) {
+      world.cells[idx(x, world.height - 1)] = WALL;
+    }
+
+    for (let x = 0; x < 6; x += 1) {
+      world.cells[idx(x, world.height - 2)] = WALL;
+    }
+
+    const initialPositions = [];
+    for (let x = 2; x <= 4; x += 1) {
+      world.cells[idx(x, 0)] = WATER;
+      initialPositions.push(x);
+    }
+
+    const initialMin = Math.min(...initialPositions);
+    const initialMax = Math.max(...initialPositions);
+
+    const state = cloneGameStateForSimulation();
+    runSimulationSteps(world, 1, state);
+
+    const positions = findElementPositions(world, WATER);
+    if (positions.length === 0) {
+      return 'Water vanished during lateral run cap test.';
+    }
+
+    const minX = positions.reduce((acc, pos) => Math.min(acc, pos.x), Infinity);
+    const maxX = positions.reduce((acc, pos) => Math.max(acc, pos.x), -Infinity);
+
+    if (minX < initialMin - waterMeta.lateralRunMax || maxX > initialMax + waterMeta.lateralRunMax) {
+      return 'Water moved laterally beyond its run cap in a single tick.';
+    }
+
+    return null;
+  }, phase4Failures);
+
+  await runCheck(() => {
+    const world = createWorld(4, 6);
+    const idx = world.idx;
+    const height = world.height;
+
+    for (let y = 0; y < height; y += 1) {
+      world.cells[idx(0, y)] = WALL;
+      world.cells[idx(world.width - 1, y)] = WALL;
+    }
+
+    for (let x = 0; x < world.width; x += 1) {
+      world.cells[idx(x, height - 1)] = WALL;
+    }
+
+    world.cells[idx(1, height - 2)] = WATER;
+    world.cells[idx(2, height - 2)] = WATER;
+    world.cells[idx(1, height - 3)] = WATER;
+    world.cells[idx(2, height - 3)] = WATER;
+
+    const state = cloneGameStateForSimulation();
+    const context = { state };
+    const flipCounts = new Uint8Array(world.cells.length);
+    const previousDirs = new Int8Array(world.lastMoveDir.length);
+
+    for (let step = 0; step < 60; step += 1) {
+      beginTick(world);
+      stepWorld(world, context);
+      endTick(world);
+      state.frame = (state.frame ?? 0) + 1;
+
+      const dirs = world.lastMoveDir;
+      for (let i = 0; i < dirs.length; i += 1) {
+        if (world.cells[i] !== WATER) {
+          previousDirs[i] = 0;
+          continue;
+        }
+
+        const dir = dirs[i];
+        const prev = previousDirs[i];
+
+        if (dir !== 0 && prev !== 0 && dir !== prev) {
+          flipCounts[i] += 1;
+        }
+
+        previousDirs[i] = dir;
+      }
+    }
+
+    let maxFlips = 0;
+    for (let i = 0; i < flipCounts.length; i += 1) {
+      if (flipCounts[i] > maxFlips) {
+        maxFlips = flipCounts[i];
+      }
+    }
+
+    if (maxFlips > 6) {
+      return `Water direction flipped ${maxFlips} times in trough test.`;
+    }
+
+    return null;
+  }, phase4Failures);
+
+  if (phase4Failures.length === 0) {
+    console.log('✅ Phase 4 ready');
+  } else {
+    const lines = ['❌ Phase 4 regressions:'];
+    for (const failure of phase4Failures) {
+      lines.push(String(failure));
+    }
+    console.error(lines.join('\n'));
+  }
+
+  return {
+    ok: combinedFailures.length === 0,
+    failures: combinedFailures,
+    phase4: {
+      ok: phase4Failures.length === 0,
+      failures: phase4Failures,
+    },
+  };
 }


### PR DESCRIPTION
## Summary
- add the water element metadata and palette alongside updated element constants
- overhaul the simulation loop with per-element updaters, seeded RNG, water physics, and QC utilities
- extend self-checks through phase 4 and wire new logging, seed controls, and toolbar protections in the main app

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68ca43e32e88832bb3b4c9c78ba571ab