### PR TITLE
Implement oil and fire simulation for Phase 6

### DIFF
--- a/src/elements.js
+++ b/src/elements.js
@@ -2,12 +2,15 @@ export const EMPTY = 0;
 export const WALL = 1;
 export const SAND = 2;
 export const WATER = 3;
+export const OIL = 4;
+export const FIRE = 5;
 
 export const ELEMENTS = [];
 
 ELEMENTS[EMPTY] = Object.freeze({
   id: EMPTY,
   name: 'Empty',
+  icon: '⬛',
   state: 'void',
   density: 0,
   immovable: true,
@@ -19,6 +22,7 @@ ELEMENTS[EMPTY] = Object.freeze({
 ELEMENTS[WALL] = Object.freeze({
   id: WALL,
   name: 'Wall',
+  icon: '🧱',
   state: 'solid',
   density: 10000,
   immovable: true,
@@ -30,6 +34,7 @@ ELEMENTS[WALL] = Object.freeze({
 ELEMENTS[SAND] = Object.freeze({
   id: SAND,
   name: 'Sand',
+  icon: '⏳',
   state: 'solid',
   density: 1700,
   immovable: false,
@@ -41,6 +46,7 @@ ELEMENTS[SAND] = Object.freeze({
 ELEMENTS[WATER] = Object.freeze({
   id: WATER,
   name: 'Water',
+  icon: '💧',
   state: 'liquid',
   density: 1000,
   immovable: false,
@@ -49,11 +55,50 @@ ELEMENTS[WATER] = Object.freeze({
   buoyancy: 1,
 });
 
+ELEMENTS[OIL] = Object.freeze({
+  id: OIL,
+  name: 'Oil',
+  icon: '🛢️',
+  state: 'liquid',
+  density: 870,
+  immovable: false,
+  viscosity: 3,
+  lateralRunMax: 3,
+  buoyancy: 2,
+  flammable: true,
+  combustion: {
+    product: FIRE,
+    igniteProbability: 0.2,
+  },
+});
+
+ELEMENTS[FIRE] = Object.freeze({
+  id: FIRE,
+  name: 'Fire',
+  icon: '🔥',
+  state: 'gas',
+  density: 1,
+  immovable: false,
+  viscosity: 0,
+  lateralRunMax: 0,
+  buoyancy: 6,
+  flammable: true,
+  fire: {
+    lifetimeMin: 20,
+    lifetimeMax: 60,
+    igniteProbability: 0.2,
+    extinguishProbability: 0.5,
+    maxSpawnPerTick: 18,
+  },
+});
+
 export const ELEMENT_IDS = Object.freeze({
   EMPTY,
   WALL,
   SAND,
   WATER,
+  OIL,
+  FIRE,
 });
 
 export const PALETTE = new Uint8ClampedArray([
@@ -65,6 +110,10 @@ export const PALETTE = new Uint8ClampedArray([
   237, 201, 81, 255,
   // WATER
   64, 128, 255, 255,
+  // OIL
+  80, 60, 40, 255,
+  // FIRE
+  252, 110, 28, 255,
 ]);
 
 export const ELEMENT_LIST = Object.freeze([
@@ -72,4 +121,6 @@ export const ELEMENT_LIST = Object.freeze([
   ELEMENTS[WALL],
   ELEMENTS[SAND],
   ELEMENTS[WATER],
+  ELEMENTS[OIL],
+  ELEMENTS[FIRE],
 ]);

--- a/src/main.js
+++ b/src/main.js
@@ -6,6 +6,8 @@ import {
   WALL,
   SAND,
   WATER,
+  OIL,
+  FIRE,
 } from './elements.js';
 import { createRenderer } from './render.js';
 import {
@@ -134,6 +136,9 @@ function clearWorld(world = Game.world) {
   world.flags.fill(0);
   if (world.lastMoveDir) {
     world.lastMoveDir.fill(0);
+  }
+  if (world.lifetimes) {
+    world.lifetimes.fill(0);
   }
   refreshParticleCount(world);
 }
@@ -366,6 +371,8 @@ export async function start() {
     WALL,
     SAND,
     WATER,
+    OIL,
+    FIRE,
   };
 
   const self = await runSelfChecksAll(Game, api);
@@ -403,7 +410,7 @@ export async function start() {
       return;
     }
     beginTick(Game.world);
-    step(Game.world, { state: Game.state });
+    step(Game.world, { state: Game.state, limits: Game.limits, metrics: Game.metrics });
     endTick(Game.world);
     Game.state.frame += 1;
   }, 1000 / PHYSICS_HZ);

--- a/src/ui.js
+++ b/src/ui.js
@@ -108,7 +108,9 @@ function createElementMenu(elements, onSelect) {
     }
     const button = document.createElement('button');
     button.type = 'button';
-    button.textContent = element.name ?? `Element ${element.id}`;
+    const label = element.name ?? `Element ${element.id}`;
+    const icon = element.icon ? `${element.icon} ` : '';
+    button.textContent = `${icon}${label}`;
     button.dataset.elementId = String(element.id);
     button.addEventListener('click', () => {
       onSelect(element.id);
@@ -232,7 +234,9 @@ export function initUI({
   function update(state) {
     const element = elements?.find((item) => item?.id === state.currentElementId);
     if (element) {
-      elementButton.textContent = `Element: ${element.name}`;
+      const label = element.name ?? `Element ${element.id}`;
+      const icon = element.icon ? `${element.icon} ` : '';
+      elementButton.textContent = `Element: ${icon}${label}`;
     }
 
     pauseButton.classList.toggle('active', Boolean(state.paused));


### PR DESCRIPTION
## Summary
- add oil and fire elements with palette entries and UI icons
- extend the simulation with oil flow, fire lifetimes, ignition and a per-tick spawn cap
- expand self-checks to cover new combustion behaviour and palette validations

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68cab8267454832b961a96e9bbe0cabe