### PR TITLE
Build material registry and interaction framework

### DIFF
--- a/src/elements.js
+++ b/src/elements.js
@@ -1,110 +1,38 @@
+import {
+  MATERIALS,
+  PALETTE,
+  MID,
+  MCAT,
+  MATERIAL_CATEGORIES,
+  getMaterial,
+  isImplemented,
+  byCategory,
+  MATERIAL_IDS,
+  createPaletteBuffer,
+  SPECIAL_IDS,
+} from './materials.js';
+
+export {
+  MATERIALS as ELEMENTS,
+  PALETTE,
+  MID as ID,
+  MCAT,
+  MATERIAL_CATEGORIES,
+  getMaterial,
+  isImplemented,
+  byCategory,
+  MATERIAL_IDS,
+  createPaletteBuffer,
+  SPECIAL_IDS,
+};
+
 export const EMPTY = 0;
 export const WALL = 1;
-export const SAND = 2;
-export const WATER = 3;
-export const OIL = 4;
-export const FIRE = 5;
+export const FIRE = SPECIAL_IDS.FIRE;
 
-export const CATEGORY_ORDER = Object.freeze([
-  'Powders',
-  'Liquids',
-  'Gases',
-  'Solids',
-  'Specials',
-]);
-
-export const ELEMENTS = [];
-
-ELEMENTS[EMPTY] = Object.freeze({
-  id: EMPTY,
-  name: 'Empty',
-  icon: '⬛',
-  state: 'void',
-  category: 'Specials',
-  density: 0,
-  immovable: true,
-  viscosity: 0,
-  lateralRunMax: 0,
-  buoyancy: 0,
-});
-
-ELEMENTS[WALL] = Object.freeze({
-  id: WALL,
-  name: 'Wall',
-  icon: '🧱',
-  state: 'solid',
-  category: 'Solids',
-  density: 10000,
-  immovable: true,
-  viscosity: 0,
-  lateralRunMax: 0,
-  buoyancy: 0,
-});
-
-ELEMENTS[SAND] = Object.freeze({
-  id: SAND,
-  name: 'Sand',
-  icon: '⏳',
-  state: 'solid',
-  category: 'Powders',
-  density: 1700,
-  immovable: false,
-  viscosity: 4,
-  lateralRunMax: 1,
-  buoyancy: -1,
-});
-
-ELEMENTS[WATER] = Object.freeze({
-  id: WATER,
-  name: 'Water',
-  icon: '💧',
-  state: 'liquid',
-  category: 'Liquids',
-  density: 1000,
-  immovable: false,
-  viscosity: 1,
-  lateralRunMax: 6,
-  buoyancy: 1,
-});
-
-ELEMENTS[OIL] = Object.freeze({
-  id: OIL,
-  name: 'Oil',
-  icon: '🛢️',
-  state: 'liquid',
-  category: 'Liquids',
-  density: 870,
-  immovable: false,
-  viscosity: 3,
-  lateralRunMax: 3,
-  buoyancy: 2,
-  flammable: true,
-  combustion: {
-    product: FIRE,
-    igniteProbability: 0.2,
-  },
-});
-
-ELEMENTS[FIRE] = Object.freeze({
-  id: FIRE,
-  name: 'Fire',
-  icon: '🔥',
-  state: 'gas',
-  category: 'Gases',
-  density: 1,
-  immovable: false,
-  viscosity: 0,
-  lateralRunMax: 0,
-  buoyancy: 6,
-  flammable: true,
-  fire: {
-    lifetimeMin: 20,
-    lifetimeMax: 60,
-    igniteProbability: 0.2,
-    extinguishProbability: 0.5,
-    maxSpawnPerTick: 18,
-  },
-});
+export const SAND = MID.SAND;
+export const WATER = MID.WATER;
+export const OIL = MID.OIL;
 
 export const ELEMENT_IDS = Object.freeze({
   EMPTY,
@@ -114,55 +42,3 @@ export const ELEMENT_IDS = Object.freeze({
   OIL,
   FIRE,
 });
-
-export const PALETTE = new Uint8ClampedArray([
-  // EMPTY
-  7, 9, 15, 255,
-  // WALL
-  54, 57, 66, 255,
-  // SAND
-  237, 201, 81, 255,
-  // WATER
-  64, 128, 255, 255,
-  // OIL
-  80, 60, 40, 255,
-  // FIRE
-  252, 110, 28, 255,
-]);
-
-const CATEGORY_INDEX = CATEGORY_ORDER.reduce((acc, name, index) => {
-  acc[name] = index;
-  return acc;
-}, Object.create(null));
-
-const orderedElements = ELEMENTS.filter((element) => {
-  return element && element.id !== EMPTY && element.id !== WALL;
-});
-
-orderedElements.sort((a, b) => {
-  const aIndex = CATEGORY_INDEX[a.category] ?? Number.MAX_SAFE_INTEGER;
-  const bIndex = CATEGORY_INDEX[b.category] ?? Number.MAX_SAFE_INTEGER;
-  if (aIndex !== bIndex) {
-    return aIndex - bIndex;
-  }
-  return a.id - b.id;
-});
-
-const elementList = [
-  ELEMENTS[EMPTY],
-  ELEMENTS[WALL],
-  ...orderedElements,
-];
-
-export const ELEMENT_LIST = Object.freeze(elementList);
-
-export const ELEMENT_CATEGORIES = Object.freeze(
-  CATEGORY_ORDER.map((name) =>
-    Object.freeze({
-      name,
-      elements: Object.freeze(
-        elementList.filter((element) => element?.category === name)
-      ),
-    })
-  )
-);

--- a/src/interactions.js
+++ b/src/interactions.js
@@ -1,0 +1,90 @@
+export const EVT = Object.freeze({
+  CONTACT: 'contact',
+  ADJACENT_TICK: 'adjacent',
+  THERMAL: 'thermal',
+});
+
+const MAX_EVENTS_PER_FRAME = 4000;
+
+export function createInteractionRouter({ getMat, rng }) {
+  let eventsThisFrame = 0;
+
+  function resetFrame() {
+    eventsThisFrame = 0;
+  }
+
+  function allow() {
+    return eventsThisFrame++ < MAX_EVENTS_PER_FRAME;
+  }
+
+  const onContactMap = new Map();
+  const onAdjacentMap = new Map();
+  const onThermalMap = new Map();
+
+  function key(a, b) {
+    return a < b ? `${a}|${b}` : `${b}|${a}`;
+  }
+
+  function onContact(a, b, fn) {
+    if (typeof fn === 'function') {
+      onContactMap.set(key(a, b), fn);
+    }
+  }
+
+  function onAdjacent(a, b, fn) {
+    if (typeof fn === 'function') {
+      onAdjacentMap.set(key(a, b), fn);
+    }
+  }
+
+  function onThermal(a, fn) {
+    if (typeof fn === 'function') {
+      onThermalMap.set(a, fn);
+    }
+  }
+
+  function contact(world, ax, ay, bx, by, idA, idB) {
+    if (!allow()) {
+      return;
+    }
+    const fn = onContactMap.get(key(idA, idB));
+    if (fn) {
+      fn(world, ax, ay, bx, by, idA, idB, rng, getMat);
+    }
+  }
+
+  function adjacentTick(world, ax, ay, bx, by, idA, idB) {
+    if (!allow()) {
+      return;
+    }
+    const fn = onAdjacentMap.get(key(idA, idB));
+    if (fn) {
+      fn(world, ax, ay, bx, by, idA, idB, rng, getMat);
+    }
+  }
+
+  function thermal(world, x, y, id, temp) {
+    if (!allow()) {
+      return;
+    }
+    const fn = onThermalMap.get(id);
+    if (fn) {
+      fn(world, x, y, id, temp, rng, getMat);
+    }
+  }
+
+  return {
+    resetFrame,
+    onContact,
+    onAdjacent,
+    onThermal,
+    contact,
+    adjacentTick,
+    thermal,
+    _debug: {
+      onContactMap,
+      onAdjacentMap,
+      onThermalMap,
+    },
+  };
+}

--- a/src/materials.js
+++ b/src/materials.js
@@ -1,0 +1,191 @@
+// Material registry and metadata definitions
+
+export const MID = Object.freeze({
+  // Powders
+  SAND: 2,
+  GUNPOWDER: 10,
+  BAKING_SODA: 11,
+  PIXIE_DUST: 12,
+  NANITE_POWDER: 13,
+  // Gases
+  OXYGEN: 20,
+  HYDROGEN: 21,
+  CARBON_DIOXIDE: 22,
+  ETHEREAL_MIST: 23,
+  ANTIMATTER_VAPOR: 24,
+  // Liquids
+  WATER: 3,
+  OIL: 30,
+  ACID: 31,
+  LUMINA: 32,
+  UMBRA: 33,
+  // Solids
+  IRON: 40,
+  WOOD: 41,
+  DRY_ICE: 42,
+  NEUTRONIUM_CORE: 43,
+  PHILOSOPHERS_STONE: 44,
+});
+
+export const MCAT = Object.freeze({
+  POWDER: 'powder',
+  GAS: 'gas',
+  LIQUID: 'liquid',
+  SOLID: 'solid',
+});
+
+const DEFAULT_FLAGS = Object.freeze({});
+
+const ensureBadge = (value, implemented) => {
+  if (typeof value === 'string') {
+    return value;
+  }
+  return implemented ? '' : 'WIP';
+};
+
+const material = (id, name, cat, rgba, opts = {}) => {
+  const implemented = Boolean(opts.implemented);
+  const mat = {
+    id,
+    name,
+    cat,
+    color: rgba,
+    implemented,
+    state: opts.state ?? cat,
+    density: opts.density ?? 1000,
+    flags: opts.flags ?? DEFAULT_FLAGS,
+    ui: { badge: ensureBadge(opts.badge, implemented) },
+  };
+  if (opts.props && typeof opts.props === 'object') {
+    Object.assign(mat, opts.props);
+  }
+  return Object.freeze(mat);
+};
+
+export const PALETTE = [];
+const C = (r, g, b, a = 255) => [r, g, b, a];
+
+const FIRE_ID = 5;
+
+export const MATERIALS = {
+  // Powders
+  [MID.SAND]: material(MID.SAND, 'Sand', MCAT.POWDER, C(218, 191, 102), {
+    implemented: true,
+    density: 1600,
+    state: 'powder',
+    props: {
+      immovable: false,
+      viscosity: 4,
+      lateralRunMax: 1,
+      buoyancy: -1,
+    },
+  }),
+  [MID.GUNPOWDER]: material(MID.GUNPOWDER, 'Gunpowder', MCAT.POWDER, C(60, 60, 60)),
+  [MID.BAKING_SODA]: material(MID.BAKING_SODA, 'Baking Soda', MCAT.POWDER, C(235, 235, 235)),
+  [MID.PIXIE_DUST]: material(MID.PIXIE_DUST, 'Pixie Dust', MCAT.POWDER, C(210, 240, 255)),
+  [MID.NANITE_POWDER]: material(MID.NANITE_POWDER, 'Nanite Powder', MCAT.POWDER, C(170, 175, 180)),
+  // Gases
+  [MID.OXYGEN]: material(MID.OXYGEN, 'Oxygen', MCAT.GAS, C(180, 220, 255)),
+  [MID.HYDROGEN]: material(MID.HYDROGEN, 'Hydrogen', MCAT.GAS, C(200, 255, 200)),
+  [MID.CARBON_DIOXIDE]: material(
+    MID.CARBON_DIOXIDE,
+    'Carbon Dioxide',
+    MCAT.GAS,
+    C(200, 200, 200),
+  ),
+  [MID.ETHEREAL_MIST]: material(MID.ETHEREAL_MIST, 'Ethereal Mist', MCAT.GAS, C(185, 205, 235)),
+  [MID.ANTIMATTER_VAPOR]: material(
+    MID.ANTIMATTER_VAPOR,
+    'Antimatter Vapor',
+    MCAT.GAS,
+    C(120, 0, 160),
+  ),
+  // Liquids
+  [MID.WATER]: material(MID.WATER, 'Water', MCAT.LIQUID, C(64, 128, 255), {
+    implemented: true,
+    density: 1000,
+    state: 'liquid',
+    props: {
+      immovable: false,
+      viscosity: 1,
+      lateralRunMax: 6,
+      buoyancy: 1,
+    },
+  }),
+  [MID.OIL]: material(MID.OIL, 'Oil', MCAT.LIQUID, C(210, 170, 90), {
+    density: 870,
+    state: 'liquid',
+    props: {
+      immovable: false,
+      viscosity: 3,
+      lateralRunMax: 3,
+      buoyancy: 2,
+      flammable: true,
+      combustion: {
+        product: FIRE_ID,
+        igniteProbability: 0.2,
+      },
+    },
+  }),
+  [MID.ACID]: material(MID.ACID, 'Acid', MCAT.LIQUID, C(170, 220, 120)),
+  [MID.LUMINA]: material(MID.LUMINA, 'Lumina', MCAT.LIQUID, C(255, 240, 120)),
+  [MID.UMBRA]: material(MID.UMBRA, 'Umbra', MCAT.LIQUID, C(15, 15, 20)),
+  // Solids
+  [MID.IRON]: material(MID.IRON, 'Iron', MCAT.SOLID, C(110, 115, 120)),
+  [MID.WOOD]: material(MID.WOOD, 'Wood', MCAT.SOLID, C(145, 110, 65)),
+  [MID.DRY_ICE]: material(MID.DRY_ICE, 'Dry Ice', MCAT.SOLID, C(210, 230, 255)),
+  [MID.NEUTRONIUM_CORE]: material(
+    MID.NEUTRONIUM_CORE,
+    'Neutronium Core',
+    MCAT.SOLID,
+    C(35, 35, 45),
+  ),
+  [MID.PHILOSOPHERS_STONE]: material(
+    MID.PHILOSOPHERS_STONE,
+    'Philosopher’s Stone',
+    MCAT.SOLID,
+    C(210, 50, 70),
+  ),
+};
+
+PALETTE[0] = C(7, 9, 15, 255);
+PALETTE[1] = C(54, 57, 66, 255);
+PALETTE[FIRE_ID] = C(252, 110, 28, 255);
+
+Object.values(MATERIALS).forEach((mat) => {
+  PALETTE[mat.id] = mat.color;
+});
+
+export const MATERIAL_CATEGORIES = [
+  { key: MCAT.POWDER, label: 'Powders' },
+  { key: MCAT.GAS, label: 'Gases' },
+  { key: MCAT.LIQUID, label: 'Liquids' },
+  { key: MCAT.SOLID, label: 'Solids' },
+];
+
+export const getMaterial = (id) => MATERIALS[id];
+export const isImplemented = (id) => Boolean(MATERIALS[id]?.implemented);
+export const byCategory = (cat) =>
+  Object.values(MATERIALS).filter((mat) => mat.cat === cat);
+export const MATERIAL_IDS = Object.freeze(Object.values(MID));
+
+export function createPaletteBuffer() {
+  const maxId = PALETTE.length;
+  const buffer = new Uint8ClampedArray(maxId * 4);
+  for (let id = 0; id < maxId; id += 1) {
+    const color = PALETTE[id];
+    const base = id * 4;
+    if (Array.isArray(color) && color.length >= 4) {
+      buffer[base] = color[0];
+      buffer[base + 1] = color[1];
+      buffer[base + 2] = color[2];
+      buffer[base + 3] = color[3];
+    } else {
+      buffer[base + 3] = 255;
+    }
+  }
+  return buffer;
+}
+
+export const SPECIAL_IDS = Object.freeze({ FIRE: FIRE_ID });
+


### PR DESCRIPTION
## Summary
- add a canonical material registry with IDs, categories, palette helpers, and exported utilities
- create a throttled interaction router, wire it into the simulation, and expose QC helpers from main
- refresh the element picker UI to show categorized materials with WIP badges and update self-checks for the new framework

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cd97ea92b8832baa748bd02bfeb3ed